### PR TITLE
action input git_commit_message is set as env variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -191,6 +191,7 @@ runs:
         PLATFORM: "${{ inputs.os_platform }}"
         GIT_USER_NAME: "${{ inputs.git_user_name }}"
         GIT_USER_EMAIL: "${{ inputs.git_user_email }}"
+        GIT_COMMIT_MESSAGE: "${{ inputs.git_commit_message }}"
         OVERRIDE_BRANCH_NAME: "${{ inputs.override_branch_name }}"
         FORCE_PUSH: "${{ inputs.force_push }}"
       shell: bash


### PR DESCRIPTION
### Summary
Thank you for your quick action on my previous PR @bodrovis ! I tried it and it works (almost)! I seem to have forgotten to map the action input to the env variable in the [other PR](https://github.com/lokalise/lokalise-pull-action/pull/20). 

I did get it to work right now by setting GIT_COMMIT_MESSAGE (as an env variable). However it goes against the documentation. This commit should fix this. 
Again please let me know if I missed anything else 😄 