### PR TITLE
allow branch folders in override branch name

### DIFF
--- a/src/commit_changes/main.go
+++ b/src/commit_changes/main.go
@@ -301,7 +301,8 @@ func sanitizeString(input string, maxLength int) string {
 		return (r >= 'a' && r <= 'z') ||
 			(r >= 'A' && r <= 'Z') ||
 			(r >= '0' && r <= '9') ||
-			r == '_' || r == '-'
+			r == '_' || r == '-' ||
+			r == '/'
 	}
 
 	var sanitized strings.Builder

--- a/src/commit_changes/main_test.go
+++ b/src/commit_changes/main_test.go
@@ -268,6 +268,12 @@ func TestSanitizeString(t *testing.T) {
 			maxLength: 10,
 			expected:  "Short",
 		},
+		{
+			name:      "Allow branch folders",
+			input:     "feature/valid-branch-name",
+			maxLength: 50,
+			expected:  "feature/valid-branch-name",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary

Allow slashes (/) in branch input to support feature branch names like feature/my-branch.

### Other Information

This is a common branching strategy and allows us to match certain workflows in our CI, where feature branches are used to pull translations from corresponding Lokalise branches.