### PR TITLE
Add pr_title and pr_body inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ additional_params: |
 
 - `custom_github_token` — Optional GitHub token to use when creating or updating the pull request. If not provided, the default `GITHUB_TOKEN` is used. This can be helpful when your workflow requires elevated permissions (e.g., assigning reviewers, interacting with protected branches, or writing outside the current repo). Make sure to keep this token secret.
 - `pr_labels` — Comma-separated list of labels to apply to the created pull request.
+- `pr_title` — Title for the pull request. If not provided, defaults to "Translations update".
+- `pr_body` — Body text for the pull request. If not provided, defaults to "This pull request updates translations from Lokalise".
 - `override_branch_name` — Optional static branch name to use instead of auto-generating one. This is useful if you want the action to update the same pull request across multiple runs (e.g., always syncing to `lokalise-sync`). If the branch already exists, it will be checked out and updated instead of creating a new one.
 - `force_push` — Whether to force push changes to the remote branch. Useful when using a static branch name and you want to overwrite any previous state (e.g., updating an existing PR). Set to `true` with caution, as this will overwrite history. Defaults to `false`.
 - `git_commit_message` — Git commit message to use. If not provided, defaults to "Translations update".

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,14 @@ inputs:
     description: 'Comma-separated list of labels to apply to the created pull request'
     required: false
     default: ''
+  pr_title:
+    description: 'Title of the pull request. If not provided, defaults to "Lokalise translations update".'
+    required: false
+    default: 'Lokalise translations update'
+  pr_body:
+    description: 'Body of the pull request. If not provided, defaults to "This PR updates translations from Lokalise."'
+    required: false
+    default: 'This PR updates translations from Lokalise.'
   max_retries:
     description: 'Maximum number of retries on rate limit errors'
     required: false
@@ -222,6 +230,8 @@ runs:
         BRANCH_NAME: ${{ steps.create-commit.outputs.branch_name }}
         BASE_REF: ${{ github.ref_name }}
         PR_LABELS: ${{ inputs.pr_labels }}
+        PR_TITLE: ${{ inputs.pr_title }}
+        PR_BODY: ${{ inputs.pr_body }}
       id: create-update-pr
       # actions/github-script@v7.0.1
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea

--- a/js/create-update-pr.js
+++ b/js/create-update-pr.js
@@ -8,6 +8,8 @@ module.exports = async ({ github, context }) => {
       .split(',')
       .map(label => label.trim())
       .filter(label => label.length > 0);
+    const prTitle = process.env.PR_TITLE;
+    const prBody = process.env.PR_BODY;
 
     if (!branchName || !baseRef) {
       throw new Error("Required environment variables are missing");
@@ -36,10 +38,10 @@ module.exports = async ({ github, context }) => {
     const { data: newPr } = await github.rest.pulls.create({
       owner: repo.owner,
       repo: repo.repo,
-      title: "Lokalise translations update",
+      title: prTitle,
       head: branchName,
       base: baseRef,
-      body: "This PR updates translations from Lokalise.",
+      body: prBody,
     });
 
     if (prLabels.length > 0) {


### PR DESCRIPTION
### Summary

This pull request introduces support for customizing the title and body of pull requests created by the action. These changes enhance the flexibility of the action, allowing users to specify custom messages for better context and clarity in their workflows.

### Other Information

This is important in our organization's workflow, where providing the JIRA ticket ID in the title is mandatory.